### PR TITLE
🐛 Fix Docker Compose: Update Kong PostgreSQL to version 11 for Konga compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
 
   # PostgreSQL Database cho Kong API Gateway
   kong-database:
-    image: postgres:13-alpine
+    image: postgres:11-alpine
     container_name: kong_db
     environment:
       POSTGRES_DB: kong


### PR DESCRIPTION
## 🎯 Mục đích
Khắc phục sự cố Docker/Docker Compose để khởi động thành công hệ thống microservices.

## 🔧 Thay đổi chính
- **Cập nhật PostgreSQL**: Thay đổi `kong-database` từ `postgres:13-alpine` xuống `postgres:11-alpine`
- **Khắc phục tương thích**: Giải quyết vấn đề tương thích giữa Konga và PostgreSQL 13

## ✅ Kết quả
- ✅ Tất cả microservices khởi động thành công
- ✅ Shell Config Service hoạt động (port 8001)
- ✅ Kong API Gateway hoạt động (ports 8000, 8002, 8443, 8444)
- ✅ Kong Database (PostgreSQL 11) hoạt động
- ✅ Shell Config Database (PostgreSQL 13) hoạt động
- ✅ Konga GUI có thể truy cập (port 1337)

## 🧪 Đã kiểm tra
- [x] `docker compose up -d` chạy thành công
- [x] Tất cả containers healthy
- [x] API endpoints phản hồi đúng
- [x] Không có lỗi trong logs

## 📋 Services đang chạy
| Service | Port | Status |
|---------|------|---------|
| shell-config-service | 8001 | ✅ Healthy |
| kong-gateway | 8000, 8002, 8443, 8444 | ✅ Healthy |
| kong-database | 5432 (internal) | ✅ Healthy |
| shell_config_db | 5432 | ✅ Healthy |
| konga-gui | 1337 | ✅ Running |

Co-authored-by: openhands <openhands@all-hands.dev>